### PR TITLE
Update and rename Shadowwind.md to Shadowbind.md

### DIFF
--- a/abilities/Shadowbind.md
+++ b/abilities/Shadowbind.md
@@ -1,4 +1,4 @@
-﻿# SHADOWWIND
+﻿# SHADOWBIND
 
 > **Level 2 Midnight Spell**  
 > **Recall Cost:** 0


### PR DESCRIPTION
Shadowbind is mispelled as Shadowwind both in the file name and in the content