### PR TITLE
Corrected 4 item damage dies

### DIFF
--- a/consumables/Dragonbloom Tea.md
+++ b/consumables/Dragonbloom Tea.md
@@ -2,4 +2,4 @@
 
 **_Consumable_**
 
-You can drink this tea to unleash a fiery breath attack. Make an Instinct Roll against all adversaries in front of you within Close range. Targets you succeed against take 2d20 physical damage using your Proficiency.
+You can drink this tea to unleash a fiery breath attack. Make an Instinct Roll against all adversaries in front of you within Close range. Targets you succeed against take d20 physical damage using your Proficiency.

--- a/consumables/Sweet Moss.md
+++ b/consumables/Sweet Moss.md
@@ -2,4 +2,4 @@
 
 **_Consumable_**
 
-You can consume this moss during a rest to clear 1d10 HP or 1d10 Stress.
+You can consume this moss during a rest to clear 1d4 HP or 1d4 Stress.

--- a/weapons/Glowing Rings.md
+++ b/weapons/Glowing Rings.md
@@ -4,5 +4,5 @@
 
 - **Trait:** Agility
 - **Range:** Very Close
-- **Damage:** d10+2 mag
+- **Damage:** d10+1 mag
 - **Burden:** Two-Handed

--- a/weapons/Spear.md
+++ b/weapons/Spear.md
@@ -4,5 +4,9 @@
 
 - **Trait:** Finesse
 - **Range:** Very Close
-- **Damage:** d8+3 phy
+- **Damage:** d10+2 phy
 - **Burden:** Two-Handed
+
+### FEATURE
+
+**_Cumbersome:_** -1 to Finesse


### PR DESCRIPTION
Dies for dragonbloom tea, sweet moss, glowing rings, and spear were incorrect.
also spear was missing its cumbersome feature.